### PR TITLE
Make EventQueue iterable

### DIFF
--- a/src/main/java/org/team114/ocelot/event/EventQueue.java
+++ b/src/main/java/org/team114/ocelot/event/EventQueue.java
@@ -4,10 +4,11 @@ import com.google.gson.JsonObject;
 import org.team114.ocelot.logging.Logger;
 
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-public class EventQueue<T extends Event> {
+public class EventQueue<T extends Event> implements Iterable<T> {
     public final Deque<T> queue = new ConcurrentLinkedDeque<>();
     public final Logger<T> log = new Logger<>();
 
@@ -19,6 +20,32 @@ public class EventQueue<T extends Event> {
         T event = queue.pollFirst();
         log.log(event);
         return event;
+    }
+
+    private class EventIterator implements Iterator<T> {
+        Iterator<T> iterator = queue.iterator();
+        @Override
+        public T next() {
+            T item = iterator.next();
+            log.log(item);
+            iterator.remove();
+            return item;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+    }
+
+    /**
+     * Returns a new iterator, which <b>removes</b> items from the queue
+     * automatically.
+     * @return an iterator for this queue
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return new EventIterator();
     }
 
     public List<T> getLog(){


### PR DESCRIPTION
This pull request proposes to make EventQueue iterable, primarily so that for-each syntax can be used. For example:
````java
for (Event event : queue) {
//handle the event
}
````

This should be merged into master after #9. For now the merge is proposed into logging-output to make the diff meaningful.