### PR TITLE
Event pipes

### DIFF
--- a/src/main/java/org/team114/ocelot/event/EventDispatcher.java
+++ b/src/main/java/org/team114/ocelot/event/EventDispatcher.java
@@ -1,0 +1,5 @@
+package org.team114.ocelot.event;
+
+public interface EventDispatcher<T extends Event> {
+    void push(T event);
+}

--- a/src/main/java/org/team114/ocelot/event/EventFeeder.java
+++ b/src/main/java/org/team114/ocelot/event/EventFeeder.java
@@ -2,10 +2,10 @@ package org.team114.ocelot.event;
 
 import java.util.List;
 
-public class SupplyEventQueue<T extends Event> extends EventQueue<T> {
+public class EventFeeder<T extends Event> implements EventDispatcher<T> {
     private List<EventQueue<? super T>> queues;
 
-    public SupplyEventQueue(List<EventQueue<? super T>> queues) {
+    public EventFeeder(List<EventQueue<? super T>> queues) {
         this.queues = queues;
     }
 
@@ -13,9 +13,5 @@ public class SupplyEventQueue<T extends Event> extends EventQueue<T> {
         for (EventQueue<? super T> queue : queues) {
             queue.push(event);
         }
-    }
-
-    public T pull() {
-        throw new UnsupportedOperationException("Supply queues don't support pulling.");
     }
 }

--- a/src/main/java/org/team114/ocelot/event/EventPipe.java
+++ b/src/main/java/org/team114/ocelot/event/EventPipe.java
@@ -4,13 +4,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-public class PipeEventQueue<I extends Event, O extends Event> extends EventQueue<I> {
+public class EventPipe<I extends Event, O extends Event> implements EventDispatcher<I> {
     private Predicate<I> acceptFilter;
     private Function<I, O> translator;
     private EventQueue<? super O> output;
 
-    public PipeEventQueue(Predicate<I> acceptFilter, Function<I, O> translator,
-                          EventQueue<? super O> output) {
+    public EventPipe(Predicate<I> acceptFilter, Function<I, O> translator,
+                     EventQueue<? super O> output) {
         this.acceptFilter = acceptFilter;
         this.translator = translator;
         this.output = output;
@@ -22,9 +22,5 @@ public class PipeEventQueue<I extends Event, O extends Event> extends EventQueue
                 .filter(acceptFilter)
                 .map(translator)
                 .forEach(output::push);
-    }
-    @Override
-    public I pull() {
-        throw new UnsupportedOperationException("Pipe queues don't support pulling.");
     }
 }

--- a/src/main/java/org/team114/ocelot/event/EventQueue.java
+++ b/src/main/java/org/team114/ocelot/event/EventQueue.java
@@ -8,19 +8,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-public class EventQueue<T extends Event> implements Iterable<T> {
+public class EventQueue<T extends Event> implements EventDispatcher<T>, Iterable<T> {
     private final Deque<T> queue = new ConcurrentLinkedDeque<>();
     protected final Logger<T> log = new Logger<>();
 
+    @Override
     public synchronized void push(T event) {
         queue.addLast(event);
     }
 
-    /**
-     * Pulls from the event queue.&nbsp;Optional method.
-     * @return the first item in the queue.
-     * @throws UnsupportedOperationException if the implementation does not support this method
-     */
     public synchronized T pull() {
         T event = queue.pollFirst();
         log.log(event);


### PR DESCRIPTION
I'm opening this pull request for discussion. The idea of the EventPipe is to act as a translator between different subsystems. This is essentially our implementation of shiming, something that has long been suggested as one of the main advantages of events. For an example of how this might work in practice:

1. The class interfacing with controller puts a ControlEvent into its EventFeeder (what information exactly the event contains is irrelevant to this PR).
2. The EventFeeder sends the event to all registered EventPipes. Registration happens in Robot and permanent (at least at the moment). This is different from PubSub, which handles registration dynamically.
3. Each EventPipe processes the event in three steps. First, it runs a filter to see if it's interested in the event. If not, it stops there. If it is interested, it runs the event through a translator, which turns it into a new event (e.g. a DriveEvent). Third, it sends the event to its output queue (e.g. the queue for the Drive subsystem).

It's unclear whether this would be an alternative for PubSub, a replacement for PubSub, or something to merge with PubSub. PubSub is dynamic (registration can happen at an arbitrary time), centralized (there's one instance that handles everything), and unsecured (anyone can get access to anything). This system is the opposite. It's static (registration happens at setup time), decentralized (different Feeders and Pipes for each system), and secured (only a class with access, in our case Robot or it's authorized delegate, can register anything). I tend to like this implementation better, but there are cases where the dynamic configuration of PubSub could come in handy. 

I strongly favor keeping both, because they have different use cases. In the long run, I would also like to design a bridge between them in case that's ever necessary. I don't see how we'd merge such different systems, and doing so would mean giving up some of the advantages of at least one system. Replacing one with the other also seems shortsighted, given that there are situations where each could prove helpful.

This implementation was suggested by @patmoore, and @Danappelxx suggested the change introduced in in 20e440f. 