### PR TITLE
Minimal logging and assertions

### DIFF
--- a/src/main/java/org/team114/ocelot/logging/AbstractLoggable.java
+++ b/src/main/java/org/team114/ocelot/logging/AbstractLoggable.java
@@ -1,0 +1,24 @@
+package org.team114.ocelot.logging;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public abstract class AbstractLoggable implements Loggable {
+    public UUID id = UUID.randomUUID();
+    public Instant timestamp = Instant.now();
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public String getTypeId() {
+        return this.getClass().getCanonicalName();
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/org/team114/ocelot/logging/ErrorItem.java
+++ b/src/main/java/org/team114/ocelot/logging/ErrorItem.java
@@ -1,0 +1,9 @@
+package org.team114.ocelot.logging;
+
+public class ErrorItem extends AbstractLoggable  {
+    public final String message;
+
+    ErrorItem(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/org/team114/ocelot/logging/Errors.java
+++ b/src/main/java/org/team114/ocelot/logging/Errors.java
@@ -1,0 +1,29 @@
+package org.team114.ocelot.logging;
+
+import java.util.function.Supplier;
+
+public class Errors {
+    private static final Errors ourInstance = new Errors();
+    public static final Logger<ErrorItem> logger = new Logger<>();
+
+    public static Errors getInstance() {
+        return ourInstance;
+    }
+
+    private Errors() {
+
+    }
+
+    public static void log(String message) {
+        logger.log(new ErrorItem(message));
+    }
+
+    public static void assertThat(boolean assertion, Supplier<String> messageSource) {
+        if (!assertion) {
+            String message = messageSource.get();
+            System.out.print("ERROR: ");
+            System.out.println(message);
+            log(message);
+        }
+    }
+}


### PR DESCRIPTION
@patmoore asked me to add something to log/print assertions, so here's a very minimal implementation. It doesn't output to a file yet, although that's something I'm planning to work on. In the meantime, it prints the assertion failure message to the screen. I'm using a singleton, because logging is the one thing all code should have access to. Feel free to merge if there are no issues, I'm going to have a nap.