### PR TITLE
Make DashboardHandle closable

### DIFF
--- a/src/main/java/org/team114/ocelot/util/DashboardHandle.java
+++ b/src/main/java/org/team114/ocelot/util/DashboardHandle.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
  *      new DashboardHandle(<KEY>).put(<VALUE>);
  *  }</pre>
  */
-public class DashboardHandle  {
+public class DashboardHandle implements AutoCloseable {
 
     /**
      * The string used to access SmartDashboard.
@@ -88,5 +88,10 @@ public class DashboardHandle  {
     @Nullable
     public boolean[] getBooleans() {
         return SmartDashboard.getBooleanArray(key, (boolean[])null);
+    }
+
+    @Override
+    public void close() {
+        SmartDashboard.delete(key);
     }
 }


### PR DESCRIPTION
Adds a close method that can be called to delete the key of the current DashboardHandle.